### PR TITLE
Fix application.conf and local credentials information

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Then, you can use, in one command line (terminal)
 # Frontend hot reload only on localhost:8080
 sbt dev
 ```
-and in an other,
+and in another,
 ```bash
 # Backend hot reload only on localhost:9000
 sbt backend/run

--- a/README.md
+++ b/README.md
@@ -39,20 +39,18 @@ heroku run bash --app APPNAME
 
 In order to run the app locally, you will need to set up a postgres database for Slick to connect to.
 
-You should then, in a file `backend/conf/secrets.conf`, define the following variable:
-```
-dbname = "???"
-user = "???"
-slick.dbs.default.db.url = "jdbc:postgresql://localhost:5432/"${dbname}"?user="${user}
+```bash
+export JDBC_DATABASE_URL = "jdbc:postgresql://localhost:5432/<db_name>?user=<your_user>&password=<your_password>"
 ```
 (5432 being the port by default for postgres databases.)
 
 Then, you can use, in one command line (terminal)
-```
+```bash
+# Frontend hot reload only on localhost:8080
 sbt dev
 ```
 and in an other,
-```
+```bash
+# Backend hot reload only on localhost:9000
 sbt backend/run
 ```
-and go to `localhost:8080`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ heroku run bash --app APPNAME
 
 ## Dev environment
 
-In order to run the app locally, you will need to set up a postgres database for Slick to connect to.
+In order to run the app locally, you will need to set up a postgres database at `localhost:5432` for Slick to connect to.
 
 ```bash
 export JDBC_DATABASE_URL = "jdbc:postgresql://localhost:5432/<db_name>?user=<your_user>&password=<your_password>"

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -7,7 +7,7 @@ apiPrefix = api
 # Default database configuration using Postgres database engine
 slick.dbs.default {
   db = {
-    url = ${?JDBC_DATABASE_URL}//${?DATABASE_URL}
+    url = ${?JDBC_DATABASE_URL}
     driver = "org.postgresql.Driver"
   }
   profile = "slick.jdbc.PostgresProfile$"

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -1,7 +1,5 @@
 # https://www.playframework.com/documentation/latest/Configuration
 
-include "secrets.conf"
-
 apiPrefix = api
 
 # Default database configuration using Postgres database engine


### PR DESCRIPTION
See https://github.com/sherpal/full-scala-scala-heroku/commit/f5686ee8fab1b56e4bbc4e6a18a12f45ea3030db#r37526937

For more complex scenarios, user can override default local values as [`jtescher/play-api application.conf`](https://github.com/jtescher/play-api/blob/master/conf/application.conf#L300-L317).

A one-liner `docker run` command or `docker-compose.yml` file can be helpful to setup PostgreSQL quickly as a pre-requisite.

Here is mine
```yaml
version: '3'

services:
  database:
    image: postgres:10-alpine
    ports:
      - '5432:5432'
    volumes:
      - postgres_data:/var/lib/postgresql/data
    environment:
      - POSTGRES_DB=michel
      - POSTGRES_USER=michel
      - POSTGRES_PASSWORD=1234
volumes:
  postgres_data:
    external:
      true
```

```bash
docker volume create --name=postgres_data
docker-compose up database
```